### PR TITLE
fix: return 404 for OAuth discovery paths while server is authless

### DIFF
--- a/src/sefaria_mcp/main.py
+++ b/src/sefaria_mcp/main.py
@@ -22,30 +22,13 @@ metrics_dict = {
 
 register_tools(mcp)
 
-# ---- WELL-KNOWN METADATA (no-auth stubs) ----
-PROTECTED_RESOURCE_DOC = {
-    # Use your actual origin, no trailing slash:
-    "resource": "https://devmcp.sefaria.org",
-    "authorization_servers": []  # <- explicitly none
-}
-
-# Add well-known OAuth endpoints using FastMCP's custom route decorator
-@mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
-async def protected_resource_endpoint(request: Request) -> JSONResponse:
-    return JSONResponse(PROTECTED_RESOURCE_DOC)
-
-@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
-async def authorization_server_endpoint(request: Request) -> JSONResponse:
-    return JSONResponse({})
-
-# Defensive variants for clients that (incorrectly) append your path:
-@mcp.custom_route("/.well-known/oauth-protected-resource/sse", methods=["GET"])
-async def protected_resource_endpoint_sse(request: Request) -> JSONResponse:
-    return JSONResponse(PROTECTED_RESOURCE_DOC)
-
-@mcp.custom_route("/.well-known/oauth-authorization-server/sse", methods=["GET"])
-async def authorization_server_endpoint_sse(request: Request) -> JSONResponse:
-    return JSONResponse({})
+# ---- WELL-KNOWN METADATA ----
+# This server is authless, so the OAuth discovery documents must be *absent*, not empty.
+# Clients treat a 200 on /.well-known/oauth-protected-resource or
+# /.well-known/oauth-authorization-server as authoritative proof that the server is
+# OAuth-protected, and then fail because there is no authorization server to talk to.
+# A 404 is the signal for "no authorization required" and lets clients connect directly.
+# If auth is ever added here, serve fully populated documents - never empty stubs.
 
 @mcp.custom_route("/healthz", methods=["GET"])
 async def healthz_endpoint(request: Request) -> JSONResponse:


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

Fixes #24 · Shortcut [sc-46552](https://app.shortcut.com/sefaria/story/46552)

## The bug

`mcp.sefaria.org` is authless, but both OAuth discovery paths answered `200` with **empty** documents:

- `/.well-known/oauth-protected-resource` → `{"resource":"https://devmcp.sefaria.org","authorization_servers":[]}`
- `/.well-known/oauth-authorization-server` → `{}`

Clients treat the *presence* of these documents as proof the server is OAuth-protected, then find nothing to register with. Concrete symptom: adding the server as a custom connector on claude.ai fails with *"Couldn't register with Sefaria MCP's sign-in service"* — the exact setup path we publish at [developers.sefaria.org](https://developers.sefaria.org/docs/the-sefaria-mcp). (Claude Code was unaffected — it skips discovery.)

## The fix

Remove the four stub routes (both paths + their `/sse`-suffixed variants) so they return **404**. Anthropic's documented fallback treats 404 as "no authorization required" and connects directly — exactly right while the server is authless. This also stops production serving the hardcoded `https://devmcp.sefaria.org` resource value. A comment marks why the paths must stay absent; if auth is ever added, the documents should return fully populated, never as empty stubs.

## Verification

Ran the app locally and probed every path before/after: the four discovery paths went `200` → `404`; `/healthz` and `/sse` unchanged; a full `fastmcp.Client` handshake against `/sse` still lists all 14 tools. (Repo has no test suite, so verification was by hand.)

**Reviewer note:** targeted `main` since recent fixes went straight there (#12–#19); happy to retarget `dev` if that's the preferred flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
