### PR TITLE
Promote dev to main: 404 empty OAuth discovery stubs

### DIFF
--- a/src/sefaria_mcp/main.py
+++ b/src/sefaria_mcp/main.py
@@ -22,30 +22,13 @@ metrics_dict = {
 
 register_tools(mcp)
 
-# ---- WELL-KNOWN METADATA (no-auth stubs) ----
-PROTECTED_RESOURCE_DOC = {
-    # Use your actual origin, no trailing slash:
-    "resource": "https://devmcp.sefaria.org",
-    "authorization_servers": []  # <- explicitly none
-}
-
-# Add well-known OAuth endpoints using FastMCP's custom route decorator
-@mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
-async def protected_resource_endpoint(request: Request) -> JSONResponse:
-    return JSONResponse(PROTECTED_RESOURCE_DOC)
-
-@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
-async def authorization_server_endpoint(request: Request) -> JSONResponse:
-    return JSONResponse({})
-
-# Defensive variants for clients that (incorrectly) append your path:
-@mcp.custom_route("/.well-known/oauth-protected-resource/sse", methods=["GET"])
-async def protected_resource_endpoint_sse(request: Request) -> JSONResponse:
-    return JSONResponse(PROTECTED_RESOURCE_DOC)
-
-@mcp.custom_route("/.well-known/oauth-authorization-server/sse", methods=["GET"])
-async def authorization_server_endpoint_sse(request: Request) -> JSONResponse:
-    return JSONResponse({})
+# ---- WELL-KNOWN METADATA ----
+# This server is authless, so the OAuth discovery documents must be *absent*, not empty.
+# Clients treat a 200 on /.well-known/oauth-protected-resource or
+# /.well-known/oauth-authorization-server as authoritative proof that the server is
+# OAuth-protected, and then fail because there is no authorization server to talk to.
+# A 404 is the signal for "no authorization required" and lets clients connect directly.
+# If auth is ever added here, serve fully populated documents - never empty stubs.
 
 @mcp.custom_route("/healthz", methods=["GET"])
 async def healthz_endpoint(request: Request) -> JSONResponse:


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

**⚠️ ON HOLD — do not merge yet.** Empirical testing inverted the premise this PR was based on; kept as a draft pending a decision.

**What this promotes:** removal of the four empty-`200` OAuth well-known stubs (#25, sc-46552). Per RFC 9728, 404 is the correct signal for an authless server.

**What testing actually showed** (devmcp on `1.7.4-dev.1`, 2026-08-17):
- Tool *usage* passes authless on all three clients tested: Claude Code CLI, claude.ai (enable via the in-chat tools menu), ChatGPT developer-mode (SSE, No Auth).
- **But** claude.ai's settings **Connect** button deterministically fails against the 404s (3/3 attempts, "Couldn't register with sign-in service"), while prod — still serving the empty stubs — connects cleanly. On current claude.ai the stubs outperform the 404s in the primary UX.
- Correction to the earlier version of this PR description: the claim that tool discovery was broken pre-fix came from the original report (upstream issue #24), not from our own testing. The prod control shows issue #24 does not reproduce today.

**Options under discussion:** revert the 404s on dev to confirm the variable; keep the stubs but fix their real bug (prod advertises `"resource": "https://devmcp.sefaria.org"`); report the 404 rejection upstream to Anthropic; prioritize streamable HTTP `/mcp` (stateless).

**Deploy mechanics if this ever merges:** the release workflow builds `v1.7.4` automatically, but deploy is a manual "deploy MCP Application" dispatch (`prod` / `mcp` / `1.7.4`) — the auto-dispatch has been failing silently since late June (expired `API_TOKEN`, 401 swallowed by curl). Prod would also pick up `v1.7.3` (`english_semantic_search` removal, 15 → 14 tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
