### PR TITLE
feat: add Streamable HTTP with SSE migration compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ MCP (Model Context Protocol) is an open protocol for connecting Large Language M
     ```bash
     python -m sefaria_mcp.main
     ```
-    The server will be available at `http://127.0.0.1:8088/sse` by default.
-    Set `SEFARIA_MCP_PORT` to override the SSE/API port (e.g., `SEFARIA_MCP_PORT=8089 python -m sefaria_mcp.main`).
+    The server listens on `http://127.0.0.1:8088` by default and serves both MCP HTTP transports:
+    - `http://127.0.0.1:8088/mcp` — Streamable HTTP (**recommended**)
+    - `http://127.0.0.1:8088/sse` — HTTP+SSE (legacy compatibility)
+
+    Set `SEFARIA_MCP_PORT` to override the MCP port (e.g., `SEFARIA_MCP_PORT=8089 python -m sefaria_mcp.main`).
     Prometheus metrics bind separately on `SEFARIA_MCP_METRICS_PORT` (default `9090`).
 
 ### Docker
@@ -71,10 +74,12 @@ MCP (Model Context Protocol) is an open protocol for connecting Large Language M
         -p 9090:9090 \
         sefaria-mcp
     ```
-    The server will be available at `http://localhost:8089/sse` and metrics at `http://localhost:9090/` (adjust the port mappings as needed).
+    The server will be available at `http://localhost:8089/mcp` (recommended) and `http://localhost:8089/sse` (legacy), with metrics at `http://localhost:9090/` (adjust the port mappings as needed).
 
 ### Usage
-- Connect your MCP-compatible client to the `/sse` endpoint.
+- Connect new MCP clients to the Streamable HTTP `/mcp` endpoint.
+- The legacy `/sse` endpoint remains available during migration for already-configured clients. It serves the same tools from the same FastMCP server.
+- Host/Origin validation is enabled for Streamable HTTP. The defaults allow loopback plus `mcp.sefaria.org` and `devmcp.sefaria.org`. Self-hosted deployments can override the comma-separated allowlists with `SEFARIA_MCP_ALLOWED_HOSTS` and `SEFARIA_MCP_ALLOWED_ORIGINS`.
 - All tool endpoints are available via the MCP protocol.
 
 ### Monitoring
@@ -84,7 +89,7 @@ MCP (Model Context Protocol) is an open protocol for connecting Large Language M
   - `mcp_tool_duration_seconds{tool_name}` – histogram of per-call durations.
   - `mcp_tool_payload_bytes{tool_name}` – histogram of response payload sizes.
   - `mcp_errors_total{tool_name,error_type}` – per-tool error counts.
-  - `mcp_active_connections` – current SSE connection gauge.
+  - `mcp_active_connections` – current MCP connection gauge.
   - Standard FastAPI instrumentation (request rate, latency, status codes, in-progress requests, etc.) from `prometheus_fastapi_instrumentator`.
 
 ## Commit Hygiene

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = [
-    "fastmcp",
+    "fastmcp>=3.4.4,<4",
     "hdate",
     "requests",
     "pillow",

--- a/src/sefaria_mcp/main.py
+++ b/src/sefaria_mcp/main.py
@@ -1,13 +1,53 @@
+import contextlib
 import logging
 import os
+from collections.abc import AsyncIterator
 
+import uvicorn
 from fastmcp import FastMCP
 from prometheus_client import start_http_server, Counter, Histogram, Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
+from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
 
 from .tools import register_tools, set_metrics
+
+
+def _csv_env(name: str, default: list[str]) -> list[str]:
+    """Read a comma-separated allowlist, falling back to a secure default."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+DEFAULT_ALLOWED_HOSTS = [
+    "127.0.0.1",
+    "127.0.0.1:*",
+    "localhost",
+    "localhost:*",
+    "[::1]",
+    "[::1]:*",
+    "mcp.sefaria.org",
+    "devmcp.sefaria.org",
+]
+DEFAULT_ALLOWED_ORIGINS = [
+    "http://127.0.0.1",
+    "http://127.0.0.1:*",
+    "http://localhost",
+    "http://localhost:*",
+    "http://[::1]",
+    "http://[::1]:*",
+    "https://mcp.sefaria.org",
+    "https://devmcp.sefaria.org",
+]
+HTTP_SECURITY = {
+    "host_origin_protection": True,
+    "allowed_hosts": _csv_env("SEFARIA_MCP_ALLOWED_HOSTS", DEFAULT_ALLOWED_HOSTS),
+    "allowed_origins": _csv_env("SEFARIA_MCP_ALLOWED_ORIGINS", DEFAULT_ALLOWED_ORIGINS),
+}
 
 
 mcp = FastMCP("Sefaria MCP 📚")
@@ -38,7 +78,8 @@ async def protected_resource_endpoint(request: Request) -> JSONResponse:
 async def authorization_server_endpoint(request: Request) -> JSONResponse:
     return JSONResponse({})
 
-# Defensive variants for clients that (incorrectly) append your path:
+
+# Defensive variants for clients that append the configured MCP path.
 @mcp.custom_route("/.well-known/oauth-protected-resource/sse", methods=["GET"])
 async def protected_resource_endpoint_sse(request: Request) -> JSONResponse:
     return JSONResponse(PROTECTED_RESOURCE_DOC)
@@ -47,18 +88,55 @@ async def protected_resource_endpoint_sse(request: Request) -> JSONResponse:
 async def authorization_server_endpoint_sse(request: Request) -> JSONResponse:
     return JSONResponse({})
 
+@mcp.custom_route("/.well-known/oauth-protected-resource/mcp", methods=["GET"])
+async def protected_resource_endpoint_mcp(request: Request) -> JSONResponse:
+    return JSONResponse(PROTECTED_RESOURCE_DOC)
+
+@mcp.custom_route("/.well-known/oauth-authorization-server/mcp", methods=["GET"])
+async def authorization_server_endpoint_mcp(request: Request) -> JSONResponse:
+    return JSONResponse({})
+
 @mcp.custom_route("/healthz", methods=["GET"])
 async def healthz_endpoint(request: Request) -> JSONResponse:
     """Health check endpoint - returns 200 OK if server is responsive."""
     return JSONResponse({"status": "ok"})
 
-# Get the FastMCP app - no need for custom wrapper
-app = mcp.http_app(transport="sse")
+# Keep each FastMCP transport as an intact ASGI app. This preserves its own
+# middleware, app state, and transport context instead of copying internal routes.
+streamable_app = mcp.http_app(
+    transport="http",
+    path="/mcp",
+    **HTTP_SECURITY,
+)
+sse_app = mcp.http_app(transport="sse", path="/sse")
+streamable_app.router.redirect_slashes = False
+sse_app.router.redirect_slashes = False
+
+
+@contextlib.asynccontextmanager
+async def combined_lifespan(_: Starlette) -> AsyncIterator[None]:
+    """Run both FastMCP transport lifespans for the shared server."""
+    async with streamable_app.lifespan(streamable_app):
+        async with sse_app.lifespan(sse_app):
+            yield
+
+
+# Match /mcp first, then delegate every legacy/custom route to the SSE app.
+# Calling the child ASGI apps directly lets each child set scope["app"] to itself,
+# which keeps FastMCP's Context.transport accurate for both transports.
+app = Starlette(
+    routes=[
+        Route("/mcp", endpoint=streamable_app),
+        Mount("/", app=sse_app),
+    ],
+    lifespan=combined_lifespan,
+)
 app.router.redirect_slashes = False
 
 logger = logging.getLogger(__name__)
 
-# Expose Prometheus metrics for MCP health and usage monitoring
+# Expose Prometheus metrics for MCP health and usage monitoring.
+# Instrument the app that Uvicorn actually serves so both transports are observed.
 instrumentator = Instrumentator(
     should_group_status_codes=True,
     should_ignore_untemplated=True,
@@ -88,7 +166,7 @@ mcp_tool_payload_bytes = Histogram(
 
 mcp_active_connections = Gauge(
     'mcp_active_connections',
-    'Number of active MCP SSE connections'
+    'Number of active MCP connections'
 )
 
 mcp_errors_total = Counter(
@@ -109,7 +187,7 @@ set_metrics(metrics_dict)
 
 def start_metrics_server() -> None:
     """Start the Prometheus metrics endpoint without crashing if the port is busy."""
-    metrics_port = 9090
+    metrics_port = int(os.getenv("SEFARIA_MCP_METRICS_PORT", "9090"))
     try:
         start_http_server(metrics_port)
     except OSError as exc:
@@ -118,7 +196,13 @@ def start_metrics_server() -> None:
 
 def main() -> None:  # pragma: no cover – simple wrapper for console_scripts
     start_metrics_server()
-    mcp.run(transport="sse", path="/sse", host="0.0.0.0", port=8088)
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=int(os.getenv("SEFARIA_MCP_PORT", "8088")),
+        lifespan="on",
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# feat: add Streamable HTTP at `/mcp` and keep SSE compatibility

## Summary

This PR adds MCP Streamable HTTP at `/mcp`.

Use `/mcp` for new client configurations.

This PR also keeps the existing `/sse` endpoint. Existing client configurations can continue to use `/sse`.

This PR makes these changes:

- Add Streamable HTTP at `/mcp`.
- Keep legacy HTTP+SSE at `/sse`.
- Enable FastMCP Host and Origin protection for `/mcp`.
- Keep each FastMCP transport in a separate ASGI application.
- Do not copy FastMCP internal routes or middleware.
- Pin FastMCP to the compatible 3.x API.
- Use the documented MCP and metrics port environment variables.
- Apply Prometheus request instrumentation to the ASGI application that Uvicorn serves.

This PR does not change the tools, resources, prompts, or authentication behavior.

## Implementation

The server creates two ASGI applications from the same `FastMCP` instance.

The applications provide these transports:

- `/mcp` provides Streamable HTTP.
- `/sse` provides legacy HTTP+SSE.

A parent Starlette application controls the request routing.

The parent application sends `/mcp` requests to the Streamable HTTP application.

The parent application sends the other MCP routes to the SSE application.

These routes include:

- `/sse`
- `/messages/`
- `/healthz`
- the existing custom metadata routes

The server keeps each FastMCP application complete. It does not copy routes from the child applications into the parent application. It does not copy FastMCP middleware between applications.

This design keeps the transport state in the correct FastMCP application. FastMCP request middleware reads this state from `scope["app"]`.

Direct delegation to each child application keeps the correct child application in `scope["app"]`.

As a result:

- `/mcp` keeps the `streamable-http` transport type.
- `/sse` keeps the `sse` transport type.

The parent application starts the lifespan of both transport applications.

The Streamable HTTP application keeps its session-manager lifecycle.

## Security

The Streamable HTTP transport enables FastMCP Host and Origin protection.

The configuration uses:

```python
host_origin_protection=True
```

The default allowlists permit loopback addresses for local development.

The default allowlists also permit these Sefaria MCP hosts:

- `mcp.sefaria.org`
- `devmcp.sefaria.org`

A self-hosted deployment can replace the default allowlists.

Use these environment variables:

- `SEFARIA_MCP_ALLOWED_HOSTS`
- `SEFARIA_MCP_ALLOWED_ORIGINS`

Each variable contains a comma-separated list.

The PR pins FastMCP to this version range:

```text
>=3.4.4,<4
```

This version range keeps the integration on the FastMCP 3.x API that this change uses.

This PR does not add authentication.

The existing no-auth metadata responses do not change.

The PR adds `/mcp` metadata variants next to the existing `/sse` variants.

## Compatibility

This PR does not remove `/sse`.

Existing client configurations can continue to use `/sse`.

Use `/mcp` for new client configurations and new documentation.

A full transition to `/mcp` can be prudent in the future. Such a change is not part of this PR. This PR does not propose a transition date or a removal date for `/sse`.

The legacy SSE message endpoint keeps its current path.

The implementation can keep this path because it preserves the complete SSE FastMCP application. It does not mount the SSE application under a new path prefix.

## Other fixes

This PR makes the documented port environment variables effective.

`SEFARIA_MCP_PORT` controls the MCP server port.

`SEFARIA_MCP_METRICS_PORT` controls the standalone Prometheus server port.

`main()` serves the combined ASGI application with Uvicorn.

The Prometheus FastAPI instrumentator is attached to this application. Therefore, Prometheus request instrumentation measures the application that receives the server traffic.

## Verification

Verified locally on a clean install. FastMCP resolved to `3.4.7`, within the pinned range.

```bash
pip install -e .
python -m sefaria_mcp.main
```

### Streamable HTTP

```bash
fastmcp list http://127.0.0.1:8088/mcp --auth none
```

The command succeeds and lists 14 tools.

### Legacy SSE

```bash
fastmcp list http://127.0.0.1:8088/sse --transport sse --auth none
```

The command succeeds and lists the same 14 tools.

### Health endpoint

```bash
curl -i http://127.0.0.1:8088/healthz
```

The response has HTTP status `200`.

### Metadata endpoints

```bash
curl -i http://127.0.0.1:8088/.well-known/oauth-protected-resource/mcp
curl -i http://127.0.0.1:8088/.well-known/oauth-protected-resource/sse
```

Both routes return `200`.

### Host protection

```bash
curl -i -X POST \
  -H 'Host: attacker.example' \
  -H 'Content-Type: application/json' \
  http://127.0.0.1:8088/mcp \
  --data '{}'
```

The server rejects the unlisted Host value with `421 Misdirected Request`. An unlisted `Origin` value on `/mcp` is likewise rejected, with `403 Forbidden`.

### Custom ports

```bash
SEFARIA_MCP_PORT=8089 \
SEFARIA_MCP_METRICS_PORT=9091 \
python -m sefaria_mcp.main
```

Both environment variables take effect: the MCP server binds `SEFARIA_MCP_PORT` and the Prometheus server binds `SEFARIA_MCP_METRICS_PORT`.

### Observed behavior

After the change:

- `/mcp` uses Streamable HTTP.
- `/sse` continues to use legacy SSE.
- Both transports expose the same 14 MCP tools.
- `/mcp/` does not redirect and returns `404`.
- `/healthz` returns `200`.
- `/mcp` rejects invalid Host values (`421`).
- `/mcp` rejects invalid Origin values (`403`).
- Custom MCP and metrics ports take effect.
- Server shutdown stops the Streamable HTTP session manager cleanly.

## Not in scope

This PR does not:

- add OAuth or another authentication system;
- remove `/sse`;
- set a date to remove `/sse`;
- change the MCP tool surface; or
- change Sefaria API behavior.